### PR TITLE
Fix markup for summary-list action

### DIFF
--- a/app/views/components/summary-list/template.njk
+++ b/app/views/components/summary-list/template.njk
@@ -21,9 +21,11 @@
     {%- if params.actions | length %}
       <ul class="govuk-summary-list__actions-list">
         {%- for action in params.actions %}
+          {%- if action.text %}
           <li class="govuk-summary-list__actions-list-item">
             {{- _actionLink(action) -}}
           </li>
+          {% endif -%}
         {% endfor -%}
       </ul>
     {% endif -%}


### PR DESCRIPTION
Don't render a list item for an action unless there is content/text provided for it.