### PR TITLE
Enable full screen mode on markdown editor

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -16,11 +16,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$preview = this.$module.querySelector('.js-markdown-preview-body .govuk-textarea')
     this.$previewButton = this.$module.querySelector('.js-markdown-preview-button')
     this.$editButton = this.$module.querySelector('.js-markdown-edit-button')
+    this.$modeButton = this.$module.querySelector('.js-markdown-mode-button')
     this.$editorInput = this.$module.querySelector('.js-markdown-editor-input')
     this.$previewBody = this.$module.querySelector('.js-markdown-preview-body')
     this.$toolbar = document.querySelector('.app-c-markdown-guidance')
     this.$editorToolbar = document.querySelector('.app-c-markdown-editor__toolbar')
     this.$module.selectionReplace = this.handleSelectionReplace.bind(this)
+
+    this.$html = document.querySelector('html')
+    this.$body = document.querySelector('body')
 
     // Enable toggle bar
     this.$head.style.display = 'block'
@@ -28,6 +32,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     // Handle button events
     this.$previewButton.addEventListener('click', this.handlePreviewButton.bind(this))
     this.$editButton.addEventListener('click', this.handleEditButton.bind(this))
+    this.$modeButton.addEventListener('click', this.handleModeButton.bind(this))
 
     // Reflect focus events
     this.reflectFocusStateToContainer(this.$input, this.$container)
@@ -127,6 +132,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     this.toggleElements()
+  }
+
+  MarkdownEditor.prototype.handleModeButton = function (event) {
+    event.preventDefault()
+    this.toggleMode()
+  }
+
+  MarkdownEditor.prototype.toggleMode = function () {
+    this.$container.classList.toggle('app-c-markdown-editor__container--full-screen')
+    this.$html.classList.toggle('app-o-template--full-screen')
+    this.$body.classList.toggle('app-o-template__body--full-screen')
+
+    if (this.$editorInput.style.height) {
+      this.$editorInput.style.height = null
+    } else {
+      this.$editorInput.style.height = (this.$container.clientHeight - 96) + 'px'
+    }
   }
 
   MarkdownEditor.prototype.toggleElements = function () {

--- a/app/assets/sass/components/_markdown-editor.scss
+++ b/app/assets/sass/components/_markdown-editor.scss
@@ -23,6 +23,19 @@
    box-shadow: $govuk-input-border-colour 0 0 0 $govuk-border-width-form-element;
  }
 
+.app-c-markdown-editor__container--full-screen {
+  z-index: 10;
+  position: fixed;
+  left: govuk-spacing(3);
+  right: govuk-spacing(3);
+  top: govuk-spacing(3);
+  bottom: govuk-spacing(3);
+
+  .gem-c-textarea, textarea {
+    height: 100%;
+  }
+}
+
  .app-c-markdown-editor__head {
    @include govuk-font(19);
    display: block;
@@ -74,6 +87,16 @@
 
    &:first-child {
      border-left-color: transparent;
+   }
+ }
+
+ .app-c-markdown-editor__button--mode {
+   float: right;
+   height: 38px;
+   color: govuk-colour('black');
+
+   @include govuk-media-query($from: tablet) {
+     height: 43px;
    }
  }
 
@@ -132,6 +155,24 @@
    background: inherit;
    fill: currentColor;
    pointer-events: none;
+ }
+
+ .app-c-markdown-editor__toolbar-icon--zoom-out {
+   display: block;
+ }
+
+ .app-c-markdown-editor__toolbar-icon--zoom-in {
+   display: none;
+ }
+
+ .app-c-markdown-editor__container--full-screen {
+   .app-c-markdown-editor__toolbar-icon--zoom-out {
+     display: none;
+   }
+
+   .app-c-markdown-editor__toolbar-icon--zoom-in {
+     display: block;
+   }
  }
 
  .app-c-markdown-editor__toolbar-button--text {

--- a/app/assets/sass/utilities/_overwrites.scss
+++ b/app/assets/sass/utilities/_overwrites.scss
@@ -14,6 +14,11 @@
   overflow: auto;
 }
 
+.app-o-template--full-screen,
+.app-o-template_body--full-screen {
+  overflow-y: hidden;
+}
+
 .app-c-textarea {
   max-width: 100%;
 }

--- a/app/views/components/markdown-editor/template.njk
+++ b/app/views/components/markdown-editor/template.njk
@@ -43,6 +43,17 @@
       <div class="app-c-markdown-editor__preview-toggle">
         <button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--muted js-markdown-edit-button">Edit markdown</button>
         <button type="button" class="app-c-markdown-editor__button js-markdown-preview-button">Preview markdown</button>
+        <button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--mode js-markdown-mode-button">
+          <svg class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--zoom-out" version="1.1" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+            <path d="M15,3l2.3,2.3l-2.89,2.87l1.42,1.42L18.7,6.7L21,9V3H15z M3,9l2.3-2.3l2.87,2.89l1.42-1.42L6.7,5.3L9,3H3V9z M9,21 l-2.3-2.3l2.89-2.87l-1.42-1.42L5.3,17.3L3,15v6H9z M21,15l-2.3,2.3l-2.87-2.89l-1.42,1.42l2.89,2.87L15,21h6V15z"></path>
+          </svg>
+          <svg class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--zoom-in" version="1.1" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+            <path d="m26.375-8.1873 2.3 2.3-2.89 2.87 1.42 1.42 2.87-2.89 2.3 2.3v-6h-6zm-12 6 2.3-2.3 2.87 2.89 1.42-1.42-2.89-2.87 2.3-2.3h-6v6zm6 12-2.3-2.3 2.89-2.87-1.42-1.42-2.87 2.89-2.3-2.3v6h6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87-2.3 2.3h6v-6z"/>
+            <path d="m3.6252 14.375 2.3 2.3-2.89 2.87 1.42 1.42 2.87-2.89 2.3 2.3v-6h-6zm-12 6 2.3-2.3 2.87 2.89 1.42-1.42-2.89-2.87 2.3-2.3h-6v6zm6 12-2.3-2.3 2.89-2.87-1.42-1.42-2.87 2.89-2.3-2.3v6h6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87-2.3 2.3h6v-6z"/>
+            <path d="m3.6252-8.1873 2.3 2.3-2.89 2.87 1.42 1.42 2.87-2.89 2.3 2.3v-6h-6zm-12 6 2.3-2.3 2.87 2.89 1.42-1.42-2.89-2.87 2.3-2.3h-6v6zm6 12-2.3-2.3 2.89-2.87-1.42-1.42-2.87 2.89-2.3-2.3v6h6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87-2.3 2.3h6v-6z"/>
+            <path d="m26.375 14.375 2.3 2.3-2.89 2.87 1.42 1.42 2.87-2.89 2.3 2.3v-6h-6zm-12 6 2.3-2.3 2.87 2.89 1.42-1.42-2.89-2.87 2.3-2.3h-6v6zm6 12-2.3-2.3 2.89-2.87-1.42-1.42-2.87 2.89-2.3-2.3v6h6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87-2.3 2.3h6v-6z"/>
+          </svg>
+        </button>
       </div>
       <div class="app-c-markdown-editor__toolbar">
         <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="{{ params.textarea.id | default('markdown-editor') }}">


### PR DESCRIPTION
### Default

<img width="1440" alt="Screenshot 2020-04-02 at 12 21 38" src="https://user-images.githubusercontent.com/788096/78244029-bcf4ac00-74dc-11ea-91cb-9d6ae8636570.png">

### Full-screen

<img width="1440" alt="Screenshot 2020-04-02 at 12 21 57" src="https://user-images.githubusercontent.com/788096/78244035-c0883300-74dc-11ea-95b1-9de4a8ad71bb.png">

[Trello card](https://trello.com/c/ynQ8YzJz)